### PR TITLE
Feature/add monorepo multiple configuration 

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -9,8 +9,9 @@ import re
 import subprocess
 import time
 import unicodedata
-from typing import Any, List
+from typing import Any
 from typing import Collection
+from typing import List
 from typing import MutableMapping
 from typing import Sequence
 
@@ -337,13 +338,14 @@ def _dive_into_file_hierarchy(dir_path: str):
     """ Iterator for crawling recursively a path.
     :note!: Not tested on windows (hardcoded '/' for path separator).
     """
-    accumulated = "" # start from empty string
+    accumulated = ''  # start from empty string
     _split = dir_path.split('/')
     while len(_split) > 0:
         accumulated = os.path.join(accumulated, _split.pop(0))
         yield accumulated
 
-def _find_all_config_files(modified_files: List[str], config_file_name: str) -> List[str]:
+
+def _find_all_config_files(modified_files: list[str], config_file_name: str) -> list[str]:
     """ Finds all the config files relative to modified files.
     Every modified file can have a :config_file_name: in its parent directory. If found, get it.
     """
@@ -362,6 +364,7 @@ def _find_all_config_files(modified_files: List[str], config_file_name: str) -> 
         ret_set.add(config_file_name)
     ret = sorted(list(ret_set))
     return ret
+
 
 def run(
         config_file: str,
@@ -452,8 +455,8 @@ def run(
         all_config_files = _find_all_config_files(_all_filenames(args), config_file)
         for _config_file in all_config_files:
             config = load_config(_config_file)
-            if len(all_config_files) > 0 :
-                print(f"Hooks from {_config_file}:")
+            if len(all_config_files) > 0:
+                print(f'Hooks from {_config_file}:')
             hooks = [
                 hook
                 for hook in all_hooks(config, store)


### PR DESCRIPTION
This is a POC to explore the monorepo feature integration in the pre-commit framework. 

# Rationale 

This MR proposes a way to use multiple configuration files, found recursively in the code tree so that multiple hooks can be applied. This is particularly useful when working with a monorepo, which is the case at my company. Every directory is a component with its own set of rules.

# Current Limitations of the implementation

This is currently a POC, only tested on Linux. No unit test were added at this stage of the proof of concept.

The current implementation does not use the subdirectory of staged files to run hooks.
This creates several problems:

   * any local configuration file (for instance pyproject.toml, .flake8 etc...) is taken from the root directory because hook are taken from root directory.
   * hooks from multiple files can interfere, because they all share the same virtual environment
    * This also means a number of problems can happen when committing files from several directories in a single commit: every hook from all the impacted directories are ran on all the committed files.

# Future project integration 

Trying to interpret the comment from https://github.com/pre-commit/pre-commit/pull/2833#issuecomment-1492975949, it seems this feature is not yet in the plan of the upstream project.

Previous requests have been made in the past, see https://github.com/pre-commit/pre-commit/issues/466 and https://github.com/pre-commit/pre-commit/issues/1140 which were closed a long time ago.

Concurrent ecosystems provide monorepo-compatible precommits: Husky, MookMe... 
